### PR TITLE
use same sort function as on PAUSE

### DIFF
--- a/build02packages.pl
+++ b/build02packages.pl
@@ -136,7 +136,7 @@ print $packagesfile "Last-Updated: ".HTTP::Date::time2str()."\n";
 print $packagesfile "\n";
 print $packagesfile sprintf(
     "%s %s %s\n", $_->{module}, $_->{modversion}, $_->{'file'}
-) foreach (sort { $a->{module} cmp $b->{module} } @modules);
+) foreach (sort { lc($a->{module}) cmp lc($b->{module}) } @modules);
 close($packagesfile);
 system("gzip -9fc cp${mirror}an/modules/02packages.details.txt > cp${mirror}an/modules/02packages.details.txt.gz");
 


### PR DESCRIPTION
Parse::CPAN::Packages::Fast has a function to quickly find a module from 02packages.details.txt using binary search. Unfortunately, this does not work if the packages file is sorted in a case-sensitive manner, like it happens with build02packages.pl. With this change the sort order should be the same like the original 02packages.details.txt.

See also https://rt.cpan.org/Public/Bug/Display.html?id=96615 for the original bug report.
